### PR TITLE
added basic Dewey handling

### DIFF
--- a/lib/quicklabels.php
+++ b/lib/quicklabels.php
@@ -248,7 +248,16 @@ function quicklabels($nums, $title_p = "0") {
                 $callnum = $newcallnum;
             }
         }
-
+        // If Dewey, split on the decimal if the Dewey string is more than 6 digits
+        if ($scheme == "DEWEY_DECIMAL") {
+          //If more than 6 numbers in the number after the cutter, put the decimal on a new line 
+            $f = strcspn($callnum, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            if ($f > 7) {
+                $deweyparts = explode(".", $callnum);
+                $newcallnum = $deweyparts[0] . "." . " " . $deweyparts[1];
+                $callnum = $newcallnum;
+            }
+        } 
         // Prepare pocket label text if called for
         if ($print_title) {
             $worldcat_url = BIBURL . '/' . $oclc . '?wskey=' . BIBKEY;


### PR DESCRIPTION
If a Dewey number is long (more than 6 digits total) the number is split at the decimal to avoid weird wrapping, e.g.
123.456
7
