### PR TITLE
fix cache limiter error

### DIFF
--- a/forms/barcode_label_output.php
+++ b/forms/barcode_label_output.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <script src="jquery/printarea/jquery.PrintArea.js" type="text/JavaScript" language="javascript"></script>
 <script src="jquery/printElement/jquery.printElement.js" type="text/JavaScript" language="javascript"></script>
 <script src="http://code.jquery.com/jquery-migrate-1.0.0.js"></script>
@@ -12,7 +13,6 @@
  *
  * Output labels grabbed from WMS API and allow user to print.
  */
-session_start();
 $barcodes         = '';
 $barcodeCount     = '';
 $labelStart       = '';


### PR DESCRIPTION
The barcode label output screen throws this error for me unless the session is initialized before anything else:

Warning: session_start(): Cannot send session cache limiter - headers already sent (output started at /home/plnlabels/labels.palni.org/unm/WMS-Labeling/forms/barcode_label_output.php:7) in /home/plnlabels/labels.palni.org/unm/WMS-Labeling/forms/barcode_label_output.php on line 15
