### PR TITLE
Move caption description under itemPart for single_part records

### DIFF
--- a/inc/quicklabels.php
+++ b/inc/quicklabels.php
@@ -345,7 +345,15 @@ function quicklabels($nums, $title_p = "0") {
         		$print_call_num = "";
         	}
         	
-        	$return_call_number = "$location_full<br />";
+        	 //removes extra space after location <br />
+
+                if ($location_full == "") {
+                  $return_call_number = "$location_full";
+                } else {
+                  $return_call_number = "$location_full<br />";
+                }      	
+        	
+        	//$return_call_number = "$location_full<br />";
         	$return_call_number .= str_replace(" ", "<br />", $callnum);
         	
         	// Return array of call number, pocket label text

--- a/inc/quicklabels.php
+++ b/inc/quicklabels.php
@@ -176,16 +176,19 @@ function quicklabels($nums, $title_p = "0") {
         		$itemparts = $copy->shelvingDesignation->itemPart;
         		$result = count($itemparts);
         		
-        		if (isset($copy->holding[0]->caption->description)) {
-        			$description = $copy->holding[0]->caption->description;
-        			$callnum = $callnum . " " . $description;
-        		}
         		if ($result > 0) {
         			for ($k = 0; $k < $result; $k++) {
         				$itempart = $itemparts[$k];
         				$callnum = $callnum . " " . $itempart;
         			}
         		}
+        		
+        		//moves caption description (876$3) under item part so it appears at the end of the call number
+        		if (isset($copy->holding[0]->caption->description)) {
+        			$description = $copy->holding[0]->caption->description;
+        			$callnum = $callnum . " " . $description;
+        		}
+        		
         		$suffixes = $copy->shelvingDesignation->suffix;
         		$result = count($suffixes);
         		if ($result > 0) {


### PR DESCRIPTION
Hi, we noticed that when retrieving single part / monograph items where the 876 $3 field is used (holding description -> caption in the API response) quicklabels was putting this data right in the middle of the call number.  So in the original code, an item with data in the 876 $3 would look like this:

PN
1997
**5326-5327**
.D268
2009

When it should look like this (at least, according to our use case):

PN
1997
.D268
2009
**5326-5327**

This pull request pushes the caption / description underneath the itemPart, which is consistent with how the data is handled in MULTI_PART records.

This change may not be generalizable for other use cases depending on how other libraries are using the 876 $3 but I'm submitting it in case it makes sense for others.

Thanks for considering!


 